### PR TITLE
Backtest uses stored parquet data

### DIFF
--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -12,15 +12,30 @@ from python.prefect import backtest as bt
 def test_backtest_produces_metrics(tmp_path: Path, monkeypatch) -> None:
     bt.MODELS_DIR = tmp_path / "models"
     bt.BEST_DIR = tmp_path / "best"
+    bt.DATA_DIR = tmp_path / "data"
     bt.MODELS_DIR.mkdir()
+    bt.DATA_DIR.mkdir()
+
+    df = pd.DataFrame(
+        {"Open": [1, 2], "High": [1, 2], "Low": [1, 2], "Close": [1, 2]},
+        index=pd.date_range("2020-01-01", periods=2, freq="D"),
+    )
+    df.to_parquet(bt.DATA_DIR / "sample.parquet")
+
     model = {"weights": [1.0] * 10}
     with open(bt.MODELS_DIR / "dummy.pkl", "wb") as f:
         pickle.dump(model, f)
 
     monkeypatch.setattr(bt, "_vectorbt_metrics", lambda p, pr: (0.5, 0.5, 0.5, pr))
-    monkeypatch.setattr(bt, "_backtrader_metrics", lambda p, s: (0.1, 0.1, 0.1, 0.1))
+    monkeypatch.setattr(
+        bt,
+        "_backtrader_metrics",
+        lambda p, s: (0.1, 0.1, 0.1, 0.1, pd.Series([1, 2], index=p.index)),
+    )
 
-    results = bt.backtest.fn(models_dir=bt.MODELS_DIR, best_dir=bt.BEST_DIR)
+    results = bt.backtest.fn(
+        models_dir=bt.MODELS_DIR, best_dir=bt.BEST_DIR, data_dir=bt.DATA_DIR
+    )
     assert results, "No results returned"
     metrics_path = bt.BEST_DIR / "metrics.csv"
     assert metrics_path.exists(), "metrics.csv not created"


### PR DESCRIPTION
## Summary
- expand backtesting utilities to read Parquet price data
- save equity curves along with metrics
- adjust unit tests for Parquet input

## Testing
- `npm run lint` *(fails: cannot find ESLint config)*
- `pytest -q` *(fails: missing packages such as prefect, yfinance, mlflow)*

------
https://chatgpt.com/codex/tasks/task_e_684f44a2c62c8333a4066102851f2a47