### PR TITLE
Add setup docs and script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: setup test lint
+
+setup:
+bash scripts/setup.sh
+
+lint:
+npm run lint
+
+test:
+pytest -q

--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ npm run dev
 - Click on "New codespace" to launch a new Codespace environment.
 - Edit files directly within the Codespace and commit and push your changes once you're done.
 
+## Installation
+
+Install the JavaScript dependencies with npm and the Python packages required for
+testing using `pip`:
+
+```bash
+npm i
+pip install -r requirements.txt
+```
+
+The optional `scripts/setup.sh` script and `Makefile` also install these
+dependencies to speed up local setup and CI.
+
 ## What technologies are used for this project?
 
 This project is built with:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Install Node.js dependencies
+npm i
+
+# Install Python requirements
+if command -v pip >/dev/null 2>&1; then
+    pip install -r requirements.txt
+else
+    echo "pip not found" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- document installing Python test dependencies
- add optional setup script and Makefile for development and CI

## Testing
- `npm run lint` *(fails: react-refresh, no-empty-object-type, no-require-imports)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy, pandas, python)*

------
https://chatgpt.com/codex/tasks/task_e_684f44a7c56483338ed584450e3b7e2d