### PR TITLE
Enable checkpoints in Prefect flows

### DIFF
--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -6,7 +6,8 @@ import pandas as pd
 import yaml
 import yfinance as yf
 from prefect import flow, task
-from .cleanup import cleanup as cleanup_flow
+from prefect.filesystems import LocalFileSystem
+from .cleanup import cleanup as cleanup_flow, remove_checkpoints
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from features.pipelines import compute_features
@@ -15,6 +16,14 @@ CONFIG_DIR = Path(__file__).resolve().parent.parent / "configs"
 ROOT_DIR = Path(__file__).resolve().parents[2]
 DATA_DIR = ROOT_DIR / "python" / "data"
 FEATURES_DIR = ROOT_DIR / "python" / "features"
+
+CHECKPOINT_BASE = Path.home() / "checkpoints"
+# ensure the result storage block exists for local checkpoints
+try:
+    LocalFileSystem(basepath=str(CHECKPOINT_BASE)).save("checkpoints", overwrite=True)
+except Exception:
+    pass
+CHECKPOINT_STORAGE = "local-file-system/checkpoints"
 
 
 def load_config(name: str) -> dict:
@@ -57,7 +66,7 @@ def build_features(path: Path, exogenous: Path | None = None) -> Path:
     subprocess.run(["dvc", "add", str(dest)], cwd=ROOT_DIR, check=True)
     return dest
 
-@flow
+@flow(persist_result=True, result_storage=CHECKPOINT_STORAGE)
 def ingest(freq: str = "day", config: dict | None = None):
     """Ingest OHLCV data as Parquet and track it with DVC."""
     if config is None:
@@ -82,22 +91,25 @@ def ingest(freq: str = "day", config: dict | None = None):
             )
             paths.append(str(path))
         results[f] = paths
+    remove_checkpoints()
     return results
 
-@flow
+@flow(persist_result=True, result_storage=CHECKPOINT_STORAGE)
 def train(config: dict | None = None):
     """Example training flow using optuna settings."""
     if config is None:
         config = load_config("optuna")
     print(f"Training models with search spaces: {list(config.keys())}")
+    remove_checkpoints()
 
-@flow
+@flow(persist_result=True, result_storage=CHECKPOINT_STORAGE)
 def backtest():
     """Dummy backtesting flow"""
     print("Running backtests...")
+    remove_checkpoints()
 
 
-@flow
+@flow(persist_result=True, result_storage=CHECKPOINT_STORAGE)
 def run_all(freq: str = "daily", do_cleanup: bool = False):
     """Run ingest, train and backtest flows sequentially, then optionally cleanup"""
     data_cfg = load_config("data")
@@ -107,9 +119,10 @@ def run_all(freq: str = "daily", do_cleanup: bool = False):
     backtest()
     if do_cleanup:
         cleanup_flow()
+    remove_checkpoints()
 
 
-@flow
+@flow(persist_result=True, result_storage=CHECKPOINT_STORAGE)
 def feature_build(freq: str = "day", exogenous: dict[str, str] | None = None):
     """Build engineered features from Parquet price data."""
     if exogenous is None:
@@ -131,6 +144,7 @@ def feature_build(freq: str = "day", exogenous: dict[str, str] | None = None):
             dest = build_features(src, exogenous=exo)
             paths.append(str(dest))
         results[f] = paths
+    remove_checkpoints()
     return results
 
 

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+from python.prefect import flows, cleanup
+
+
+def test_flows_have_checkpoints():
+    assert flows.ingest.persist_result is True
+    assert flows.ingest.result_storage == flows.CHECKPOINT_STORAGE
+    assert flows.train.persist_result is True
+    assert flows.backtest.persist_result is True
+    assert flows.run_all.persist_result is True
+    assert flows.feature_build.persist_result is True
+
+
+def test_remove_checkpoints(tmp_path):
+    base = cleanup.CHECKPOINT_BASE
+    if base.exists():
+        for p in base.iterdir():
+            if p.is_dir():
+                for sub in p.iterdir():
+                    if sub.is_file():
+                        sub.unlink()
+                p.rmdir()
+    base.mkdir(exist_ok=True)
+    (base / "manual").mkdir()
+    assert any(base.iterdir())
+    cleanup.remove_checkpoints.fn()
+    assert not any(base.iterdir())


### PR DESCRIPTION
## Summary
- enable result checkpoints for Prefect flows
- create local filesystem block to store checkpoints
- ensure checkpoints get cleaned up
- test checkpoint configuration and cleanup behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4491d6688333a64b052b5f0053a4