### PR TITLE
Enhance backtesting flow for mlruns

### DIFF
--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -10,20 +10,22 @@ from python.prefect import backtest as bt
 
 
 def test_backtest_produces_metrics(tmp_path: Path, monkeypatch) -> None:
-    bt.MODELS_DIR = tmp_path / "models"
-    bt.BEST_DIR = tmp_path / "best"
+    bt.MLRUNS_DIR = tmp_path / "mlruns"
+    bt.BEST_DIR = bt.MLRUNS_DIR / "best"
     bt.DATA_DIR = tmp_path / "data"
-    bt.MODELS_DIR.mkdir()
-    bt.DATA_DIR.mkdir()
+    model_artifact = bt.MLRUNS_DIR / "0" / "run" / "artifacts"
+    model_artifact.mkdir(parents=True)
+    freq_dir = bt.DATA_DIR / "day"
+    freq_dir.mkdir(parents=True)
 
     df = pd.DataFrame(
         {"Open": [1, 2], "High": [1, 2], "Low": [1, 2], "Close": [1, 2]},
         index=pd.date_range("2020-01-01", periods=2, freq="D"),
     )
-    df.to_parquet(bt.DATA_DIR / "sample.parquet")
+    df.to_parquet(freq_dir / "sample.parquet")
 
     model = {"weights": [1.0] * 10}
-    with open(bt.MODELS_DIR / "dummy.pkl", "wb") as f:
+    with open(model_artifact / "model.pkl", "wb") as f:
         pickle.dump(model, f)
 
     monkeypatch.setattr(bt, "_vectorbt_metrics", lambda p, pr: (0.5, 0.5, 0.5, pr))
@@ -34,7 +36,7 @@ def test_backtest_produces_metrics(tmp_path: Path, monkeypatch) -> None:
     )
 
     results = bt.backtest.fn(
-        models_dir=bt.MODELS_DIR, best_dir=bt.BEST_DIR, data_dir=bt.DATA_DIR
+        mlruns_dir=bt.MLRUNS_DIR, best_dir=bt.BEST_DIR, data_dir=bt.DATA_DIR
     )
     assert results, "No results returned"
     metrics_path = bt.BEST_DIR / "metrics.csv"


### PR DESCRIPTION
## Summary
- update backtesting to load models from `mlruns` and iterate over frequency folders
- save metrics/equity in `mlruns/best`
- update unit tests for new structure

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68528b6d2f048333a1c53807638309b2