### PR TITLE
Fix merge leftovers in train script

### DIFF
--- a/python/prefect/train_and_evaluate.py
+++ b/python/prefect/train_and_evaluate.py
@@ -178,12 +178,8 @@ def run_study(model: str, label: str, freq: str, space: Dict[str, Any], n_trials
     X_full = np.vstack([X_train, X_val])
     y_full = np.concatenate([y_train, y_val])
     best_model = train_model(study.best_params, X_full, y_full)
-<<<<<<< codex/replace-placeholder-models-with-real-implementations
-    save_model(name, best_model)
-=======
-    with open(MODELS_DIR / f"{model}_{freq}_{label}.pkl", "wb") as f:
-        pickle.dump(best_model, f)
->>>>>>> main
+    model_name = f"{model}_{freq}_{label}"
+    save_model(model_name, best_model)
 
     exp = mlflow.get_experiment_by_name(exp_name)
     if exp is None:


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers in `train_and_evaluate.py`
- always save trained models via `save_model`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685291b9ea608333bd20532e00d2e689