### PR TITLE
Add CLI test and cleanup training module

### DIFF
--- a/python/prefect/train_and_evaluate.py
+++ b/python/prefect/train_and_evaluate.py
@@ -178,12 +178,7 @@ def run_study(model: str, label: str, freq: str, space: Dict[str, Any], n_trials
     X_full = np.vstack([X_train, X_val])
     y_full = np.concatenate([y_train, y_val])
     best_model = train_model(study.best_params, X_full, y_full)
-<<<<<<< codex/replace-placeholder-models-with-real-implementations
-    save_model(name, best_model)
-=======
-    with open(MODELS_DIR / f"{model}_{freq}_{label}.pkl", "wb") as f:
-        pickle.dump(best_model, f)
->>>>>>> main
+    save_model(f"{model}_{freq}_{label}", best_model)
 
     exp = mlflow.get_experiment_by_name(exp_name)
     if exp is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import types, sys
+if 'yfinance' not in sys.modules:
+    yf = types.SimpleNamespace(download=lambda *a, **k: None)
+    sys.modules['yfinance'] = yf

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+import python.cli as cli
+
+
+def test_run_all_invokes_flows(monkeypatch):
+    calls = []
+    def record(name):
+        def inner(*args, **kwargs):
+            calls.append(name)
+        return inner
+    monkeypatch.setattr(cli, "ingest", record("ingest"))
+    monkeypatch.setattr(cli, "feature_build", record("feature_build"))
+    monkeypatch.setattr(cli, "train_all", record("train_all"))
+    monkeypatch.setattr(cli, "backtest", record("backtest"))
+    monkeypatch.setattr(cli, "cleanup", record("cleanup"))
+    monkeypatch.setattr(cli, "_disk_free_gb", lambda path=Path("."): 10)
+
+    spawned = {}
+    class DummyPopen:
+        def __init__(self, args, *a, **k):
+            spawned["args"] = args
+    monkeypatch.setattr(cli.subprocess, "Popen", DummyPopen)
+
+    cli.main(["run-all", "--freq", "day", "--cleanup", "no"])
+
+    assert calls == ["ingest", "feature_build", "train_all", "backtest"]
+    assert spawned.get("args", [])[0] == "streamlit"


### PR DESCRIPTION
## Summary
- patch training flow to remove merge artifact and save model using constructed name
- stub yfinance in tests
- add test verifying `cli.run-all` sequence

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685291c1211c833394c0d34de3fd7af8