### PR TITLE
Add CLI entry and lazy model import

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,4 @@
+from python.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/python/models/__init__.py
+++ b/python/models/__init__.py
@@ -1,7 +1,5 @@
 """Collection of simple model implementations used in Optuna studies."""
 
-from . import lightgbm, catboost, tabnet, prophet, n_linear, lstm, tft, autoformer, informer, patchtst, timesnet, finrl_ppo
-
 __all__ = [
     "lightgbm",
     "catboost",
@@ -16,3 +14,10 @@ __all__ = [
     "timesnet",
     "finrl_ppo",
 ]
+
+
+def __getattr__(name):
+    if name in __all__:
+        import importlib
+        return importlib.import_module(f".{name}", __name__)
+    raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
## Summary
- add `cli.py` at the repository root that forwards to `python.cli.main`
- lazily import model modules in `python.models` to avoid heavy optional deps during tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68529901097883338dcd04a9f2389441