### PR TITLE
Add per-frequency date ranges in ingest

### DIFF
--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -109,12 +109,16 @@ def ingest(freq: str = "day", config: dict | None = None):
 
     results: dict[str, list[str]] = {}
     for f in freqs:
+        range_cfg = config.get("date_ranges", {}).get(f, {})
+        start = range_cfg.get("start_date", config.get("start_date"))
+        end = range_cfg.get("end_date", config.get("end_date"))
+
         paths = []
         for ticker in config["tickers"]:
             path = fetch_and_store(
                 ticker,
-                config["start_date"],
-                config["end_date"],
+                start,
+                end,
                 f,
             )
             paths.append(str(path))

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -28,3 +28,39 @@ def test_ingest_sample_data(tmp_path, monkeypatch):
         freq="day",
     )
     assert path.exists()
+
+
+def test_ingest_per_freq_ranges(tmp_path, monkeypatch):
+    flows.DATA_DIR = tmp_path / "data"
+    flows.DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(flows.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(flows, "ensure_dvc_repo", lambda: None)
+    monkeypatch.setattr(flows, "remove_checkpoints", lambda: None, raising=False)
+
+    calls: list[tuple[str, str, str]] = []
+
+    def fake_fetch(ticker: str, start: str, end: str, freq: str):
+        calls.append((start, end, freq))
+        dest = flows.DATA_DIR / "raw" / freq
+        dest.mkdir(parents=True, exist_ok=True)
+        p = dest / f"{ticker}.parquet"
+        p.write_text("x")
+        return p
+
+    monkeypatch.setattr(flows, "fetch_and_store", fake_fetch)
+
+    cfg = {
+        "start_date": "2020-01-01",
+        "end_date": "2020-01-10",
+        "tickers": ["TEST"],
+        "frequencies": ["day", "hour"],
+        "date_ranges": {"day": {"start_date": "2021-01-01", "end_date": "2021-01-10"}},
+    }
+
+    flows.ingest.fn("all", config=cfg)
+
+    assert calls == [
+        ("2021-01-01", "2021-01-10", "day"),
+        ("2020-01-01", "2020-01-10", "hour"),
+    ]


### PR DESCRIPTION
## Summary
- allow ingest flow to override start/end dates with `config['date_ranges'][freq]`
- test ingest flow reading per-frequency ranges

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68529ceec994833386cb96389851227b