### PR TITLE
Guard ATR fallback when ta-lib missing

### DIFF
--- a/python/features/pipelines.py
+++ b/python/features/pipelines.py
@@ -49,7 +49,8 @@ def _price_action_features(df: pd.DataFrame) -> pd.DataFrame:
     feats["wick_lower"] = lower_wick
     feats["wick_ratio_upper"] = upper_wick / range_
     feats["wick_ratio_lower"] = lower_wick / range_
-    feats["ATR"] = talib.ATR(high, low, close)
+    atr = talib.ATR(high, low, close) if talib is not None else pd.Series([0] * len(df), index=df.index)
+    feats["ATR"] = atr
     return feats
 
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -45,6 +45,24 @@ def test_compute_features_with_exogenous(monkeypatch):
     assert len(feats) == len(df)
 
 
+def test_compute_features_without_talib(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "Open": [1, 2],
+            "High": [1, 2],
+            "Low": [0, 1],
+            "Close": [1, 2],
+        },
+        index=pd.date_range("2021-01-01", periods=2, freq="D"),
+    )
+
+    monkeypatch.setattr(p, "talib", None, raising=False)
+    monkeypatch.setattr(p, "_talib_features", lambda df: pd.DataFrame(index=df.index))
+
+    feats = p.compute_features(df)
+    assert list(feats["ATR"]) == [0, 0]
+
+
 
 def test_label_generation_functions():
     df = pd.DataFrame({"Close": [1.0, 1.02, 0.99, 1.01]})


### PR DESCRIPTION
## Summary
- avoid crash if ta-lib isn't installed when computing ATR
- add regression test for the fallback

## Testing
- `pytest tests/test_features.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prefect')*

------
https://chatgpt.com/codex/tasks/task_e_6852a8aa28348333ad8dbd08134028f3