### PR TITLE
Fix Optuna range parsing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,6 +85,8 @@ cli.py
 configs/
     data.yaml
     optuna.yaml
+        # lists with two numbers denote a [min, max] range
+        # longer lists or strings are sampled categorically
     cleanup.yaml
 data/
 features/


### PR DESCRIPTION
## Summary
- parse numeric ranges with `suggest_int`/`suggest_float`
- document the YAML space behaviour
- add a test for sampling ranges

## Testing
- `pytest tests/test_train_and_evaluate.py::test_range_sampling -q`
- `pytest -q` *(fails: test_eurex_holiday_flag)*

------
https://chatgpt.com/codex/tasks/task_e_6852a8ab6d388333921797091c85154e