### PR TITLE
Fix Prefect task usage for local runs

### DIFF
--- a/python/prefect/cleanup.py
+++ b/python/prefect/cleanup.py
@@ -27,7 +27,12 @@ def load_config(name: str) -> dict:
 @task(log_prints=True)
 def dvc_gc_workspace() -> None:
     """Run ``dvc gc -w`` to drop unused data objects from the workspace."""
-    logger = get_run_logger()
+    try:
+        logger = get_run_logger()
+    except Exception:  # outside flow context
+        import logging
+
+        logger = logging.getLogger(__name__)
     cmd = ["dvc", "gc", "-w"]
     logger.info("Running %s", " ".join(cmd))
     try:


### PR DESCRIPTION
## Summary
- make Prefect tasks callable outside flow runs
- allow cleanup task to log without active context
- fallback to original function when monkeypatched
- install dependencies for data calendar use

## Testing
- `npm run build`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ac791db083339ea000890f231834