### PR TITLE
Clean unused imports in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-import types, sys
+import sys
+import types
 if 'yfinance' not in sys.modules:
     yf = types.SimpleNamespace(download=lambda *a, **k: None)
     sys.modules['yfinance'] = yf

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -1,5 +1,3 @@
-import os
-from pathlib import Path
 from python.prefect import flows, cleanup
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-import sys
 from pathlib import Path
 
 import python.cli as cli

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-import importlib
 from python.prefect import flows
 
 

--- a/tests/test_feature_build.py
+++ b/tests/test_feature_build.py
@@ -1,5 +1,4 @@
 import pandas as pd
-from pathlib import Path
 
 from python.prefect import flows
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import pandas as pd
 from python.prefect import flows
 


### PR DESCRIPTION
## Summary
- remove stale imports across several tests
- fix lint issue in `conftest.py`

## Testing
- `ruff check tests`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852aed550e883339e6f1c61c3e8b743