### PR TITLE
Add missing import for remove_checkpoints

### DIFF
--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -11,7 +11,7 @@ from prefect.filesystems import LocalFileSystem
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from features.pipelines import compute_features
-from .cleanup import _resample_5min, cleanup_flow
+from .cleanup import _resample_5min, cleanup_flow, remove_checkpoints
 
 CONFIG_DIR = Path(__file__).resolve().parent.parent / "configs"
 ROOT_DIR = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary
- include `remove_checkpoints` when importing cleanup utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852af2c4abc83339d4c0cfb0c3e08fa