### PR TITLE
Fix tests and update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ catboost
 pytorch-lightning
 stable-baselines3
 gymnasium
+pandas_market_calendars


### PR DESCRIPTION
## Summary
- add missing pandas_market_calendars dependency

## Testing
- `npm install`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b165f4e88333b7f417a9ea563193