### PR TITLE
Fix mlflow installation step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ environment:
    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
    ```
 
-2. Install required system packages via Homebrew. `ta-lib` is needed for the
-   feature pipeline and `dvc`/`mlflow` provide data and model tracking:
+2. Install required system packages via Homebrew. `ta-lib` and `dvc` are needed
+   for feature generation and data versioning. `mlflow` will be installed later
+   via `pip`:
 
    ```bash
-   brew install python@3.12 node ta-lib dvc mlflow
+   brew install python@3.12 node ta-lib dvc
    ```
 
 3. Create a Python virtual environment and activate it:


### PR DESCRIPTION
## Summary
- clarify Homebrew instructions and install `mlflow` via `pip`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6852b511d4ec833397a9e9b1038eaa41