### PR TITLE
Fix README missing clone step

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ pytest -q
 The project has been tested on a MacBook M1. Follow these steps to set up the
 environment:
 
+0. Clone this repository (DVC requires a Git repository):
+
+   ```bash
+   git clone https://github.com/yourname/dax-ai-oracle.git
+   cd dax-ai-oracle
+   ```
+
 1. Install the command line tools and Homebrew:
 
    ```bash


### PR DESCRIPTION
## Summary
- clarify that repository must be cloned so DVC can initialize

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6852b93e2f6c8333a366e47b56d0a914