### PR TITLE
Update minute ingestion and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Prefect Flows -> Data Lake (Parquet + DVC) -> Feature Pipelines
 | Day       | 10 years      | `data/raw/1d/`     | kept |
 
 Data is pulled from `yfinance` and stored as Parquet with DVC deduplication.
+Minute downloads are requested in eight-day windows to stay within the API limits.
 
 ### Model families
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,6 +27,7 @@ Prefect Flows -> Data Lake (Parquet + DVC) -> Feature Pipelines
 | Day       | 10 years      | `data/raw/1d/`     | kept                                         |
 
 Data comes from `yfinance` and is stored as Parquet with DVC for deduplicated storage.
+Minute data is downloaded in eight-day chunks to comply with API limits.
 
 ## 3. Feature Engineering
 


### PR DESCRIPTION
## Summary
- add MAX_MINUTE_SPAN constant and use 8‑day minute chunks
- keep minute index tz-aware until concat, then convert to naive
- compute cutoff in UTC
- adjust tests for 8‑day limit and timezone handling
- document the 8‑day chunking in README and ARCHITECTURE

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c189a8b48333b13b9c349a256299