### PR TITLE
Fix installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ environment:
    via `pip`:
 
    ```bash
-   brew install python@3.12 node ta-lib dvc
+   brew install python@3.11 node ta-lib dvc
    ```
 
 3. Create a Python virtual environment and activate it:
 
    ```bash
-   python3 -m venv .venv
+   python3.11 -m venv .venv
    source .venv/bin/activate
    ```
 


### PR DESCRIPTION
## Summary
- fix Python version in installation instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6852c76af724833382ce534f288cbaa7