### PR TITLE
Implement minute start cutoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Prefect Flows -> Data Lake (Parquet + DVC) -> Feature Pipelines
 
 Data is pulled from `yfinance` and stored as Parquet with DVC deduplication.
 Minute downloads are requested in eight-day windows to stay within the API limits.
+If a start date lies more than 30 days in the past, it is adjusted to this
+cutoff because minute history is only available for the recent month.
 Tickers that fail to download are skipped with a warning.
 
 ### Model families


### PR DESCRIPTION
## Summary
- cap old minute data when ingesting historical prices
- mention minute data cutoff in the README
- test that start dates are capped to 30 days

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c98c665c8333bf962c89c7481434