### PR TITLE
Fix yfinance cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ environment:
    npm install
    ```
 
+6. Disable the default yfinance SQLite cache (or set a writable cache path) to
+   avoid `OperationalError: unable to open database file` errors:
+
+   ```bash
+   export YFINANCE_NO_CACHE=1
+   ```
+
 After these steps the command below will ingest data, train the models,
 backtest and launch the Streamlit dashboard on `localhost:8501`:
 

--- a/python/dashboard/app.py
+++ b/python/dashboard/app.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import pickle
 import time
 from pathlib import Path
+import os
 
 import pandas as pd
 import streamlit as st
+
+# ensure yfinance does not use the default SQLite cache
+os.environ.setdefault("YFINANCE_NO_CACHE", "1")
 
 try:  # optional, can be missing in test environment
     import yfinance as yf
@@ -43,7 +47,7 @@ def show_live() -> None:
     st.header("Live View")
     if yf is not None:
         try:
-            data = yf.download("^GDAXI", period="1d", interval="1m")
+            data = yf.download("^GDAXI", period="1d", interval="1m", threads=False)
             st.line_chart(data["Close"])
         except Exception as exc:  # pragma: no cover - network issues
             st.warning(f"Could not download data: {exc}")

--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 import subprocess
 import sys
+import os
 
 import pandas as pd
 import yaml
 import yfinance as yf
 import time
+
+# disable SQLite caching to avoid OperationalError when cache path is unwritable
+os.environ.setdefault("YFINANCE_NO_CACHE", "1")
 try:
     from yfinance.exceptions import YFPricesMissingError  # type: ignore
 except Exception:  # pragma: no cover - fallback for tests without yfinance
@@ -70,6 +74,7 @@ def _download_with_retry(
                 interval=interval,
                 auto_adjust=False,
                 progress=False,
+                threads=False,
             )
         except YFPricesMissingError:
             raise
@@ -151,8 +156,7 @@ def fetch_and_store(ticker: str, start: str, end: str, freq: str) -> Path:
         print(f"Warning: failed to download {ticker}: {exc}")
         return path
 
-    if isinstance(df.index, pd.DatetimeIndex) and df.index.tz is not None:
-        df.index = pd.to_datetime(df.index).tz_convert(None)
+    df.index = pd.to_datetime(df.index, utc=True).tz_convert(None)
 
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -13,7 +13,7 @@ def test_ingest_sample_data(tmp_path, monkeypatch):
 
     # fake yfinance download
     class FakeYF:
-        def download(self, ticker, start, end, interval, auto_adjust, progress):
+        def download(self, ticker, start, end, interval, auto_adjust, progress, threads=False):
             index = pd.date_range("2020-01-01", periods=2, freq="D", tz="UTC")
             df = pd.DataFrame({"Open": [1, 2], "High": [1, 2], "Low": [1, 2], "Close": [1, 2]}, index=index)
             return df
@@ -72,7 +72,7 @@ def test_fetch_and_store_minute_chunks(tmp_path, monkeypatch):
 
     calls = []
 
-    def fake_download(ticker, start, end, interval, auto_adjust, progress):
+    def fake_download(ticker, start, end, interval, auto_adjust, progress, threads=False):
         calls.append((start, end))
         idx = pd.date_range(start, periods=1, freq="T", tz="UTC")
         return pd.DataFrame({"Open": [1], "High": [1], "Low": [1], "Close": [1]}, index=idx)


### PR DESCRIPTION
## Summary
- disable SQLite cache for yfinance downloads
- pass `threads=False` to yfinance
- document `YFINANCE_NO_CACHE` setup step
- adjust tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c98f8da883339dfe4ab4105f9df2