### PR TITLE
Add gitattributes and macOS cleanup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.DS_Store export-ignore
+__MACOSX export-ignore
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Remove macOS artifacts
+        run: bash scripts/remove_macos_artifacts.sh
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/scripts/remove_macos_artifacts.sh
+++ b/scripts/remove_macos_artifacts.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Remove macOS resource forks and metadata files
+set -e
+find . -name '*.DS_Store' -type f -print -delete
+find . -name '__MACOSX' -type d -print0 | xargs -0 -r rm -rf


### PR DESCRIPTION
## Summary
- exclude macOS artifacts with `.gitattributes`
- remove `.DS_Store` and `__MACOSX` folders in CI
- add script `remove_macos_artifacts.sh` to clean repository

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6853d28d07d48333a270dbed81ae520b