### PR TITLE
Improve dashboard plotly fallback

### DIFF
--- a/python/dashboard/app.py
+++ b/python/dashboard/app.py
@@ -23,7 +23,8 @@ except Exception:  # pragma: no cover - optional dependency
 
 try:  # optional, fallback plotting backend
     import plotly.express as px
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
+    st.warning("Plotly not installed")
     px = None
 
 ROOT = Path(__file__).resolve().parents[2]

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,73 @@
+import importlib
+import builtins
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+import streamlit as st
+
+
+def reload_app(monkeypatch, import_error=False):
+    """Reload dashboard.app with optional ImportError for plotly."""
+    orig_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if import_error and name == "plotly.express":
+            raise ImportError
+        return orig_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    if "python.dashboard.app" in importlib.sys.modules:
+        del importlib.sys.modules["python.dashboard.app"]
+    return importlib.import_module("python.dashboard.app")
+
+
+def setup_equity(tmp_path, app):
+    best = tmp_path / "mlruns" / "best" / "model1"
+    best.mkdir(parents=True)
+    series = pd.Series([1, 2, 3])
+    series.to_csv(best / "test_equity.csv")
+    app.BEST_DIR = tmp_path / "mlruns" / "best"
+
+
+def test_plotly_missing(monkeypatch, tmp_path):
+    warnings = []
+    monkeypatch.setattr(st, "warning", lambda msg: warnings.append(msg))
+    line_calls = []
+    monkeypatch.setattr(st, "line_chart", lambda data: line_calls.append(data))
+    monkeypatch.setattr(st, "plotly_chart", lambda fig: (_ for _ in ()).throw(AssertionError("plotly_chart called")))
+
+    app = reload_app(monkeypatch, import_error=True)
+    setup_equity(tmp_path, app)
+
+    app.show_equity()
+
+    assert "Plotly not installed" in warnings[0]
+    assert line_calls, "line_chart not called"
+
+
+def test_plotly_available(monkeypatch, tmp_path):
+    warnings = []
+    monkeypatch.setattr(st, "warning", lambda msg: warnings.append(msg))
+    plot_calls = []
+    def fake_plotly(fig):
+        plot_calls.append(fig)
+    monkeypatch.setattr(st, "plotly_chart", fake_plotly)
+    line_calls = []
+    monkeypatch.setattr(st, "line_chart", lambda data: line_calls.append(data))
+
+    app = reload_app(monkeypatch, import_error=False)
+    setup_equity(tmp_path, app)
+
+    # patch px.line to return a dummy figure
+    class DummyFig:
+        pass
+    monkeypatch.setattr(app.px, "line", lambda *a, **k: DummyFig())
+
+    app.show_equity()
+
+    assert not warnings, "warning emitted"
+    assert plot_calls, "plotly_chart not called"
+    assert not line_calls, "line_chart should not be used when plotly available"


### PR DESCRIPTION
## Summary
- warn when Plotly import fails and fall back to `st.line_chart`
- add unit tests for dashboard plotting behavior

## Testing
- `pytest tests/test_dashboard.py -q`
- `pytest -q` *(fails: No module named 'prefect', 'yaml', 'optuna')*

------
https://chatgpt.com/codex/tasks/task_e_6853d2910b588333b93c3957a1081998