### PR TITLE
Add weekly scheduled tests workflow

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,40 @@
+name: Weekly tests
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: |
+          pip install pandas numpy scikit-learn optuna mlflow prefect stable-baselines3 gymnasium
+          pip install git+https://github.com/ranaroussi/yfinance.git
+      - run: pytest -q | tee pytest.log
+        id: tests
+        continue-on-error: true
+      - if: steps.tests.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const log = fs.readFileSync('pytest.log', 'utf8').split('\n').slice(-50).join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Scheduled tests failed on ${new Date().toISOString().slice(0,10)}`,
+              body: `The scheduled weekly tests failed.\n\nLast 50 lines of log:\n\n\`\`\`\n${log}\n\`\`\``
+            });
+      - if: steps.tests.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
## Summary
- run scheduled tests once a week
- install latest yfinance from GitHub for the run
- open an issue if tests fail

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'SequentialTaskRunner')*

------
https://chatgpt.com/codex/tasks/task_e_6853d28959708333890c538d4a81c780