### PR TITLE
Improve setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ streamlit run python/dashboard/app.py
 
 ## Development
 
-All documentation resides in the [docs](docs/) folder.
+All documentation resides in the [docs](docs/) folder. The minimum supported
+Python version is **3.11**.
 Run the tests with:
 
 ```bash
@@ -95,6 +96,13 @@ environment:
    ```bash
    brew install python@3.11 node ta-lib dvc
    ```
+   On Linux you can build TA‑Lib manually:
+
+   ```bash
+   wget http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
+   tar -xzf ta-lib-0.4.0-src.tar.gz && cd ta-lib
+   ./configure --prefix=/usr/local && make && sudo make install
+   ```
 
 3. Create a Python virtual environment and activate it:
 
@@ -103,10 +111,25 @@ environment:
    source .venv/bin/activate
    ```
 
-4. Install PyTorch with MPS support and the remaining Python requirements:
+4. Install PyTorch and the remaining Python requirements. For CPU only:
+
+   ```bash
+   pip install torch torchvision torchaudio
+   ```
+   For NVIDIA GPUs use the CUDA 12.1 wheels:
+
+   ```bash
+   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+   ```
+   macOS users with Apple Silicon can instead enable MPS:
 
    ```bash
    pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/mps
+   ```
+
+   Afterwards install the remaining requirements:
+
+   ```bash
    pip install -r requirements.txt
    ```
 
@@ -116,7 +139,14 @@ environment:
    npm install
    ```
 
-6. Disable the default yfinance SQLite cache (or set a writable cache path) to
+6. (Optional) Install additional Python extras:
+
+   ```bash
+   pip install .[dashboard]
+   pip install .[experiments]
+   ```
+
+7. Disable the default yfinance SQLite cache (or set a writable cache path) to
    avoid `OperationalError: unable to open database file` errors:
 
    ```bash

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,13 +109,44 @@ python cli.py run-all --freq all --cleanup yes
 
 which ingests data, trains models, backtests, cleans up and launches the dashboard at `localhost:8501`.
 
-## 11. Operation & Monitoring
+## 11. Environment Setup
+
+The codebase requires **Python 3.11** or newer. Install PyTorch and TA‑Lib before running the flows.
+
+- Build TA‑Lib manually if your system packages do not provide it:
+
+  ```bash
+  wget http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
+  tar -xzf ta-lib-0.4.0-src.tar.gz && cd ta-lib
+  ./configure --prefix=/usr/local && make && sudo make install
+  ```
+
+- Install PyTorch for CPU only:
+
+  ```bash
+  pip install torch torchvision torchaudio
+  ```
+
+- Or for NVIDIA GPUs with CUDA 12.1:
+
+  ```bash
+  pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+  ```
+
+- Optional extras can be installed with:
+
+  ```bash
+  pip install .[dashboard]
+  pip install .[experiments]
+  ```
+
+## 12. Operation & Monitoring
 
 - Prefect UI (port 4200) shows logs and resumes flows after crashes.
 - MLflow UI (port 5000) compares metrics and allows artifact download.
 - A disk guard triggers cleanup when free space drops below 5 GB.
 
-## 12. Optional Extensions
+## 13. Optional Extensions
 
 - Online learning with `river` for minute data.
 - Ensemble stacking (e.g. LightGBM + PatchTST output into a Meta‑CatBoost).


### PR DESCRIPTION
## Summary
- document minimum Python version (3.11)
- include instructions for CPU/GPU PyTorch installation
- explain how to build TA‑Lib on Linux
- show how to install optional extras
- add environment setup section to architecture docs

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prefect')*

------
https://chatgpt.com/codex/tasks/task_e_6853d28c8ea483339943135517757c96