### PR TITLE
Add yfinance compatibility args

### DIFF
--- a/python/dashboard/app.py
+++ b/python/dashboard/app.py
@@ -4,6 +4,7 @@ import pickle
 import time
 from pathlib import Path
 import os
+import inspect
 
 import pandas as pd
 import streamlit as st
@@ -15,6 +16,10 @@ try:  # optional, can be missing in test environment
     import yfinance as yf
 except Exception:  # pragma: no cover - optional dependency
     yf = None
+
+_COMPAT_ARGS = {"progress": False}
+if yf is not None and "threads" in inspect.signature(yf.download).parameters:
+    _COMPAT_ARGS["threads"] = False
 
 try:  # optional dependency for equity curves
     import vectorbt as vbt
@@ -47,7 +52,7 @@ def show_live() -> None:
     st.header("Live View")
     if yf is not None:
         try:
-            data = yf.download("^GDAXI", period="1d", interval="1m", threads=False)
+            data = yf.download("^GDAXI", period="1d", interval="1m", **_COMPAT_ARGS)
             st.line_chart(data["Close"])
         except Exception as exc:  # pragma: no cover - network issues
             st.warning(f"Could not download data: {exc}")

--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -5,8 +5,13 @@ import os
 
 import pandas as pd
 import yaml
+import inspect
 import yfinance as yf
 import time
+
+_COMPAT_ARGS = {"progress": False}
+if "threads" in inspect.signature(yf.download).parameters:
+    _COMPAT_ARGS["threads"] = False
 
 # disable SQLite caching to avoid OperationalError when cache path is unwritable
 os.environ.setdefault("YFINANCE_NO_CACHE", "1")
@@ -74,8 +79,7 @@ def _download_with_retry(
                 end=end.to_pydatetime(),
                 interval=interval,
                 auto_adjust=False,
-                progress=False,
-                threads=False,
+                **_COMPAT_ARGS,
             )
         except YFPricesMissingError:
             raise

--- a/tests/test_yfinance_compat.py
+++ b/tests/test_yfinance_compat.py
@@ -1,0 +1,77 @@
+import importlib
+import types
+import sys
+import pandas as pd
+
+
+def load_flows(has_threads: bool, monkeypatch):
+    if has_threads:
+        def download(ticker, start=None, end=None, interval=None, auto_adjust=False, progress=True, threads=True):
+            return pd.DataFrame()
+    else:
+        def download(ticker, start=None, end=None, interval=None, auto_adjust=False, progress=True):
+            return pd.DataFrame()
+    stub = types.SimpleNamespace(download=download)
+    monkeypatch.setitem(sys.modules, 'yfinance', stub)
+    if 'python.prefect.flows' in sys.modules:
+        del sys.modules['python.prefect.flows']
+    return importlib.import_module('python.prefect.flows')
+
+
+def load_app(has_threads: bool, monkeypatch):
+    if has_threads:
+        def download(ticker, period=None, interval=None, progress=True, threads=True):
+            return pd.DataFrame({'Close': [1]})
+    else:
+        def download(ticker, period=None, interval=None, progress=True):
+            return pd.DataFrame({'Close': [1]})
+    stub = types.SimpleNamespace(download=download)
+    monkeypatch.setitem(sys.modules, 'yfinance', stub)
+    dummy_st = types.SimpleNamespace(
+        header=lambda *a, **k: None,
+        line_chart=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        info=lambda *a, **k: None,
+        experimental_rerun=lambda: None,
+        session_state={},
+    )
+    monkeypatch.setitem(sys.modules, 'streamlit', dummy_st)
+    if 'python.dashboard.app' in sys.modules:
+        del sys.modules['python.dashboard.app']
+    return importlib.import_module('python.dashboard.app')
+
+
+def test_flows_with_threads(monkeypatch):
+    flows = load_flows(True, monkeypatch)
+    called = {}
+    def record(*a, **k):
+        called.update(k)
+        return pd.DataFrame()
+    monkeypatch.setattr(flows, 'yf', types.SimpleNamespace(download=record))
+    flows._download_with_retry('T', pd.Timestamp('2020-01-01'), pd.Timestamp('2020-01-02'), '1d', attempts=1)
+    assert flows._COMPAT_ARGS == {'progress': False, 'threads': False}
+    assert called.get('threads') is False
+    assert called.get('progress') is False
+
+
+def test_flows_without_threads(monkeypatch):
+    flows = load_flows(False, monkeypatch)
+    called = {}
+    def record(*a, **k):
+        called.update(k)
+        return pd.DataFrame()
+    monkeypatch.setattr(flows, 'yf', types.SimpleNamespace(download=record))
+    flows._download_with_retry('T', pd.Timestamp('2020-01-01'), pd.Timestamp('2020-01-02'), '1d', attempts=1)
+    assert flows._COMPAT_ARGS == {'progress': False}
+    assert 'threads' not in called
+    assert called.get('progress') is False
+
+
+def test_app_with_threads(monkeypatch):
+    app = load_app(True, monkeypatch)
+    assert app._COMPAT_ARGS == {'progress': False, 'threads': False}
+
+
+def test_app_without_threads(monkeypatch):
+    app = load_app(False, monkeypatch)
+    assert app._COMPAT_ARGS == {'progress': False}


### PR DESCRIPTION
## Summary
- add runtime compatibility logic for yfinance threads parameter
- use `_COMPAT_ARGS` for all `yf.download` calls
- unit test `_COMPAT_ARGS` behavior with and without `threads`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'SequentialTaskRunner')*

------
https://chatgpt.com/codex/tasks/task_e_6853d29660f48333a5a6f7935c1c44fa