### PR TITLE
Handle missing prophet dependency

### DIFF
--- a/python/models/prophet.py
+++ b/python/models/prophet.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
-from prophet import Prophet
+try:
+    from prophet import Prophet
+except ImportError as exc:  # pragma: no cover - optional dependency
+    raise RuntimeError(
+        "Prophet-Modell angefordert, 'prophet' fehlt. Installiere mit extras 'experiments'."
+    ) from exc
 
 
 def train(X: np.ndarray, y: np.ndarray, params: dict | None = None) -> dict:

--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -68,15 +68,25 @@ def _download_with_retry(
     """Call ``yf.download`` with a few retries on failure."""
     for i in range(attempts):
         try:
-            return yf.download(
-                ticker,
-                start=start.to_pydatetime(),
-                end=end.to_pydatetime(),
-                interval=interval,
-                auto_adjust=False,
-                progress=False,
-                threads=False,
-            )
+            try:
+                return yf.download(
+                    ticker,
+                    start=start.to_pydatetime(),
+                    end=end.to_pydatetime(),
+                    interval=interval,
+                    auto_adjust=False,
+                    progress=False,
+                    threads=False,
+                )
+            except TypeError:
+                return yf.download(
+                    ticker,
+                    start=start.to_pydatetime(),
+                    end=end.to_pydatetime(),
+                    interval=interval,
+                    auto_adjust=False,
+                    progress=False,
+                )
         except YFPricesMissingError:
             raise
         except Exception as exc:  # noqa: BLE001

--- a/tests/test_prophet_missing.py
+++ b/tests/test_prophet_missing.py
@@ -1,0 +1,23 @@
+import importlib
+import builtins
+import sys
+import pytest
+
+
+def test_prophet_missing_raises(monkeypatch):
+    if 'python.models.prophet' in sys.modules:
+        del sys.modules['python.models.prophet']
+
+    orig_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == 'prophet':
+            raise ImportError('no prophet')
+        return orig_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+
+    with pytest.raises(RuntimeError) as exc:
+        importlib.import_module('python.models.prophet')
+
+    assert "Prophet-Modell" in str(exc.value)


### PR DESCRIPTION
## Summary
- handle absent `prophet` optional dependency
- fallback to yfinance without `threads` arg when needed
- test runtime error for missing prophet import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d290e10c8333a751a104a7f9a0db