### PR TITLE
Add yfinance version caption

### DIFF
--- a/python/dashboard/app.py
+++ b/python/dashboard/app.py
@@ -16,6 +16,11 @@ try:  # optional, can be missing in test environment
 except Exception:  # pragma: no cover - optional dependency
     yf = None
 
+if yf is not None:
+    st.sidebar.caption(f"yfinance {yf.__version__}")
+else:
+    st.sidebar.caption("yfinance unavailable")
+
 try:  # optional dependency for equity curves
     import vectorbt as vbt
 except Exception:  # pragma: no cover - optional dependency

--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -75,7 +75,6 @@ def _download_with_retry(
                 interval=interval,
                 auto_adjust=False,
                 progress=False,
-                threads=False,
             )
         except YFPricesMissingError:
             raise

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import streamlit as st
+
+
+def load_app(yf_module):
+    sys.modules.pop('python.dashboard.app', None)
+    if yf_module is None:
+        sys.modules.pop('yfinance', None)
+        import builtins
+        orig_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == 'yfinance':
+                raise ImportError
+            return orig_import(name, *args, **kwargs)
+
+        builtins.__import__, token = fake_import, orig_import
+        try:
+            return importlib.import_module('python.dashboard.app')
+        finally:
+            builtins.__import__ = token
+    else:
+        sys.modules['yfinance'] = yf_module
+        return importlib.import_module('python.dashboard.app')
+
+
+def test_caption_with_yfinance(monkeypatch):
+    msgs = []
+    monkeypatch.setattr(st.sidebar, 'caption', lambda msg: msgs.append(msg))
+    yf_mod = types.SimpleNamespace(__version__='0.1', download=lambda *a, **k: None)
+    load_app(yf_mod)
+    assert msgs[-1] == 'yfinance 0.1'
+
+
+def test_caption_without_yfinance(monkeypatch):
+    msgs = []
+    monkeypatch.setattr(st.sidebar, 'caption', lambda msg: msgs.append(msg))
+    load_app(None)
+    assert msgs[-1] == 'yfinance unavailable'


### PR DESCRIPTION
## Summary
- show yfinance version in dashboard sidebar or display availability notice
- remove `threads` arg from `_download_with_retry`
- add dashboard unit tests for sidebar caption

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d28797488333b4165ad7e57afbe1