### PR TITLE
Remove duplicate CLI entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ Dashboard lädt nur Pickle-Modelle + Metrics-CSV (≤ 200 kB/Modell), keine Raw-
 10 Verzeichnis­struktur
 
 .
-├── cli.py                # entrypoint: python cli.py run-all
+├── python/cli.py         # entrypoint: dax-ai-oracle run-all
 ├── configs/
 │   ├── data.yaml         # Start/End dates, tickers
 │   ├── optuna.yaml       # HP search spaces
@@ -144,7 +144,7 @@ Dashboard lädt nur Pickle-Modelle + Metrics-CSV (≤ 200 kB/Modell), keine Raw-
 │   └── cleanup.py
 └── dashboard/            # Streamlit app
 
-python cli.py run-all --freq all --cleanup yes
+dax-ai-oracle run-all --freq all --cleanup yes
 lädt Daten → trainiert → backtestet → räumt auf → startet Dashboard auf localhost:8501.
 
 ⸻

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ More details are available in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 Run the full pipeline and start the dashboard with:
 
 ```bash
-python cli.py run-all --freq all --cleanup yes
+dax-ai-oracle run-all --freq all --cleanup yes
 ```
 
 This command ingests data, trains models, backtests, cleans up and launches the dashboard at `localhost:8501`.
@@ -151,6 +151,6 @@ After these steps the command below will ingest data, train the models,
 backtest and launch the Streamlit dashboard on `localhost:8501`:
 
 ```bash
-python cli.py run-all --freq all --cleanup yes
+dax-ai-oracle run-all --freq all --cleanup yes
 ```
 

--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,0 @@
-from python.cli import main
-
-if __name__ == "__main__":
-    main()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,7 +82,7 @@ Streamlit (auto refresh every 60 s) exposes live signals, a leaderboard and pe
 ## 10. Directory Layout
 
 ```text
-cli.py
+python/cli.py
 configs/
     data.yaml
     optuna.yaml
@@ -104,7 +104,7 @@ dashboard/
 Run everything via
 
 ```bash
-python cli.py run-all --freq all --cleanup yes
+dax-ai-oracle run-all --freq all --cleanup yes
 ```
 
 which ingests data, trains models, backtests, cleans up and launches the dashboard at `localhost:8501`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dashboard = ["plotly", "vectorbt"]
 experiments = ["prophet"]
 
 [project.scripts]
-dax-oracle = "python.cli:main"
+dax-ai-oracle = "python.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- delete the root `cli.py` wrapper
- register a `dax-ai-oracle` console script
- update docs to call the new entrypoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6853db3eb7c4833397c7c2edbc1e2c02