### PR TITLE
Centralize yfinance compatibility settings

### DIFF
--- a/python/dashboard/app.py
+++ b/python/dashboard/app.py
@@ -4,10 +4,10 @@ import pickle
 import time
 from pathlib import Path
 import os
-import inspect
 
 import pandas as pd
 import streamlit as st
+from utils.yf_compat import _COMPAT_ARGS
 
 # ensure yfinance does not use the default SQLite cache
 os.environ.setdefault("YFINANCE_NO_CACHE", "1")
@@ -21,10 +21,6 @@ if yf is not None:
     st.sidebar.caption(f"yfinance {yf.__version__}")
 else:
     st.sidebar.caption("yfinance unavailable")
-
-_COMPAT_ARGS = {"progress": False}
-if yf is not None and "threads" in inspect.signature(yf.download).parameters:
-    _COMPAT_ARGS["threads"] = False
 
 try:  # optional dependency for equity curves
     import vectorbt as vbt

--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -5,21 +5,13 @@ import os
 
 import pandas as pd
 import yaml
-import inspect
-import yfinance as yf
 import time
 
-_COMPAT_ARGS = {"progress": False}
-if "threads" in inspect.signature(yf.download).parameters:
-    _COMPAT_ARGS["threads"] = False
+from utils.yf_compat import _COMPAT_ARGS, YFPricesMissingError
+import yfinance as yf
 
 # disable SQLite caching to avoid OperationalError when cache path is unwritable
 os.environ.setdefault("YFINANCE_NO_CACHE", "1")
-try:
-    from yfinance.exceptions import YFPricesMissingError  # type: ignore
-except Exception:  # pragma: no cover - fallback for tests without yfinance
-    class YFPricesMissingError(Exception):
-        pass
 from prefect import flow, task
 from prefect.filesystems import LocalFileSystem
 from prefect.runtime.flow_run import FlowRunContext

--- a/python/utils/yf_compat.py
+++ b/python/utils/yf_compat.py
@@ -1,0 +1,21 @@
+import inspect
+import os
+
+try:
+    import yfinance as yf
+except Exception:  # pragma: no cover - optional dependency
+    yf = None
+
+_COMPAT_ARGS: dict[str, bool] = {"progress": False}
+if yf is not None and "threads" in inspect.signature(yf.download).parameters:
+    _COMPAT_ARGS["threads"] = False
+
+# ensure yfinance does not use the default SQLite cache
+os.environ.setdefault("YFINANCE_NO_CACHE", "1")
+
+try:
+    from yfinance.exceptions import YFPricesMissingError  # type: ignore
+except Exception:  # pragma: no cover - fallback for tests without yfinance
+    class YFPricesMissingError(Exception):
+        """Raised when yfinance returns no data."""
+        pass


### PR DESCRIPTION
## Summary
- centralize yfinance download compatibility logic
- use shared `_COMPAT_ARGS` and `YFPricesMissingError` in Prefect flows and Streamlit app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prefect')*

------
https://chatgpt.com/codex/tasks/task_e_6853db0a96d08333b37f0eaaec9ac9c2