### PR TITLE
Fix yf progress flag usage

### DIFF
--- a/python/dashboard/app.py
+++ b/python/dashboard/app.py
@@ -22,7 +22,7 @@ if yf is not None:
 else:
     st.sidebar.caption("yfinance unavailable")
 
-_COMPAT_ARGS = {"progress": False}
+_COMPAT_ARGS: dict[str, bool] = {}
 if yf is not None and "threads" in inspect.signature(yf.download).parameters:
     _COMPAT_ARGS["threads"] = False
 

--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -9,7 +9,7 @@ import inspect
 import yfinance as yf
 import time
 
-_COMPAT_ARGS = {"progress": False}
+_COMPAT_ARGS: dict[str, bool] = {}
 if "threads" in inspect.signature(yf.download).parameters:
     _COMPAT_ARGS["threads"] = False
 
@@ -80,7 +80,6 @@ def _download_with_retry(
                 end=end.to_pydatetime(),
                 interval=interval,
                 auto_adjust=False,
-                progress=False,
                 **_COMPAT_ARGS,
 
 
@@ -92,7 +91,6 @@ def _download_with_retry(
                 end=end.to_pydatetime(),
                 interval=interval,
                 auto_adjust=False,
-                progress=False,
                 **_COMPAT_ARGS,
                 )
 

--- a/tests/test_yfinance_compat.py
+++ b/tests/test_yfinance_compat.py
@@ -49,9 +49,9 @@ def test_flows_with_threads(monkeypatch):
         return pd.DataFrame()
     monkeypatch.setattr(flows, 'yf', types.SimpleNamespace(download=record))
     flows._download_with_retry('T', pd.Timestamp('2020-01-01'), pd.Timestamp('2020-01-02'), '1d', attempts=1)
-    assert flows._COMPAT_ARGS == {'progress': False, 'threads': False}
+    assert flows._COMPAT_ARGS == {'threads': False}
     assert called.get('threads') is False
-    assert called.get('progress') is False
+    assert 'progress' not in called
 
 
 def test_flows_without_threads(monkeypatch):
@@ -62,16 +62,16 @@ def test_flows_without_threads(monkeypatch):
         return pd.DataFrame()
     monkeypatch.setattr(flows, 'yf', types.SimpleNamespace(download=record))
     flows._download_with_retry('T', pd.Timestamp('2020-01-01'), pd.Timestamp('2020-01-02'), '1d', attempts=1)
-    assert flows._COMPAT_ARGS == {'progress': False}
+    assert flows._COMPAT_ARGS == {}
     assert 'threads' not in called
-    assert called.get('progress') is False
+    assert 'progress' not in called
 
 
 def test_app_with_threads(monkeypatch):
     app = load_app(True, monkeypatch)
-    assert app._COMPAT_ARGS == {'progress': False, 'threads': False}
+    assert app._COMPAT_ARGS == {'threads': False}
 
 
 def test_app_without_threads(monkeypatch):
     app = load_app(False, monkeypatch)
-    assert app._COMPAT_ARGS == {'progress': False}
+    assert app._COMPAT_ARGS == {}


### PR DESCRIPTION
## Summary
- remove redundant progress flag in Prefect flows
- adjust dashboard progress defaults
- update yfinance compatibility tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prefect')*

------
https://chatgpt.com/codex/tasks/task_e_6853db019b1c8333a08fe133a88ef10b