### PR TITLE
Resolve conflict in dashboard tests

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -4,9 +4,10 @@ import types
 import builtins
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
+import pandas as pd
 import streamlit as st
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 
 def load_app(yf_module):
@@ -44,9 +45,6 @@ def test_caption_without_yfinance(monkeypatch):
     monkeypatch.setattr(st.sidebar, 'caption', lambda msg: msgs.append(msg))
     load_app(None)
     assert msgs[-1] == 'yfinance unavailable'
-=======
-import pandas as pd
-import streamlit as st
 
 
 def reload_app(monkeypatch, import_error=False):


### PR DESCRIPTION
## Summary
- fix merge conflict markers in `tests/test_dashboard.py`
- keep helper functions and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prefect')*

------
https://chatgpt.com/codex/tasks/task_e_6853daef0a088333b4f6a9057974f577