### PR TITLE
Add ruff lint and coverage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,26 @@ on:
   pull_request:
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install ruff
+      - run: ruff check .
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Remove macOS artifacts
         run: bash scripts/remove_macos_artifacts.sh
+        shell: bash
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -19,6 +33,10 @@ jobs:
       - run: npm run lint
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      - run: pip install pandas numpy scikit-learn optuna mlflow prefect stable-baselines3 gymnasium
-      - run: pytest -q
+          python-version: '3.11'
+      - run: pip install pandas numpy scikit-learn optuna mlflow prefect stable-baselines3 gymnasium pytest pytest-cov
+      - run: pytest --cov=python --cov-report=xml -q
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}
+          path: coverage.xml


### PR DESCRIPTION
## Summary
- add ruff lint job
- run pytest with coverage on Ubuntu and Windows

## Testing
- `ruff check .` *(fails: E402 in tests/test_yf_integration.py)*
- `pytest --cov=python --cov-report=xml -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6853db5a8b288333af31eb28fad52c77