### PR TITLE
Initialize Prefect checkpoints lazily

### DIFF
--- a/python/cli.py
+++ b/python/cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import subprocess
 
 import yaml
-from python.prefect.flows import ingest, feature_build, backtest
+from python.prefect.flows import ingest, feature_build, backtest, init as init_prefect
 from python.prefect.train_and_evaluate import train_all
 from python.prefect.cleanup import cleanup, _disk_free_gb
 
@@ -26,6 +26,7 @@ def _ensure_disk_space(threshold_gb: float = 5.0) -> None:
 
 
 def main(argv=None):
+    init_prefect()
     parser = argparse.ArgumentParser(
         description="Command line interface for Prefect flows"
     )

--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -39,12 +39,31 @@ FEATURES_DIR = ROOT_DIR / "python" / "features"
 MAX_MINUTE_SPAN = pd.Timedelta(days=8)
 
 CHECKPOINT_BASE = Path.home() / "checkpoints"
-# ensure the result storage block exists for local checkpoints
-try:
-    LocalFileSystem(basepath=str(CHECKPOINT_BASE)).save("checkpoints", overwrite=True)
-except Exception:
-    pass
 CHECKPOINT_STORAGE = "local-file-system/checkpoints"
+
+
+def init() -> None:
+    """Create checkpoint directory and Prefect storage block on demand."""
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    try:
+        CHECKPOINT_BASE.mkdir(parents=True)
+        logger.info("Created checkpoint directory %s", CHECKPOINT_BASE)
+    except FileExistsError:
+        logger.debug("Checkpoint directory %s already exists", CHECKPOINT_BASE)
+    except PermissionError as exc:
+        logger.error("Cannot create checkpoint directory %s: %s", CHECKPOINT_BASE, exc)
+        return
+
+    try:
+        LocalFileSystem(basepath=str(CHECKPOINT_BASE)).save("checkpoints")
+        logger.info("Created Prefect block 'checkpoints'")
+    except FileExistsError:
+        logger.debug("Prefect block 'checkpoints' already exists")
+    except PermissionError as exc:
+        logger.error("Cannot create Prefect block 'checkpoints': %s", exc)
 
 
 def _maybe_call(task_func, *args, **kwargs):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ def test_run_all_invokes_flows(monkeypatch):
         def inner(*args, **kwargs):
             calls.append(name)
         return inner
+    monkeypatch.setattr(cli, "init_prefect", lambda: None)
     monkeypatch.setattr(cli, "ingest", record("ingest"))
     monkeypatch.setattr(cli, "feature_build", record("feature_build"))
     monkeypatch.setattr(cli, "train_all", record("train_all"))


### PR DESCRIPTION
## Summary
- add `init` helper in `python/prefect/flows.py` to set up checkpoint storage
- call the initializer from the CLI
- adapt CLI unit test to stub the new function

## Testing
- `pytest -q` *(fails: SyntaxError in tests/test_dashboard.py)*

------
https://chatgpt.com/codex/tasks/task_e_6853db27ed50833391271e4efece4959