### PR TITLE
Set YFINANCE_NO_CACHE early

### DIFF
--- a/python/dashboard/app.py
+++ b/python/dashboard/app.py
@@ -4,13 +4,12 @@ import pickle
 import time
 from pathlib import Path
 import os
+# ensure yfinance does not use the default SQLite cache
+os.environ.setdefault("YFINANCE_NO_CACHE", "1")
 
 import pandas as pd
 import streamlit as st
 from utils.yf_compat import _COMPAT_ARGS
-
-# ensure yfinance does not use the default SQLite cache
-os.environ.setdefault("YFINANCE_NO_CACHE", "1")
 
 try:  # optional, can be missing in test environment
     import yfinance as yf

--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -2,6 +2,8 @@ from pathlib import Path
 import subprocess
 import sys
 import os
+# disable SQLite caching to avoid OperationalError when cache path is unwritable
+os.environ.setdefault("YFINANCE_NO_CACHE", "1")
 import logging
 
 import pandas as pd
@@ -15,8 +17,6 @@ _COMPAT_ARGS: dict[str, bool] = {}
 if "threads" in inspect.signature(yf.download).parameters:
     _COMPAT_ARGS["threads"] = False
 
-# disable SQLite caching to avoid OperationalError when cache path is unwritable
-os.environ.setdefault("YFINANCE_NO_CACHE", "1")
 from prefect import flow, task
 from prefect.filesystems import LocalFileSystem
 from prefect.runtime.flow_run import FlowRunContext


### PR DESCRIPTION
## Summary
- ensure yfinance cache is disabled early in Prefect flows
- ensure Streamlit dashboard also disables yfinance cache in import block

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6853dd3b6d248333a6ad8894aaae2f2f