### PR TITLE
Handle YFNoDataError in ingestion

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -44,7 +44,6 @@ def test_caption_without_yfinance(monkeypatch):
     monkeypatch.setattr(st.sidebar, 'caption', lambda msg: msgs.append(msg))
     load_app(None)
     assert msgs[-1] == 'yfinance unavailable'
-=======
 import pandas as pd
 import streamlit as st
 


### PR DESCRIPTION
## Summary
- add fallback import for `YFNoDataError`
- catch `YFNoDataError` alongside `YFPricesMissingError`
- fix leftover merge marker in dashboard test

## Testing
- `pytest -q` *(fails: AttributeError: None has no attribute 'line')*

------
https://chatgpt.com/codex/tasks/task_e_6853db120a988333bacae2227f4a32dd