### PR TITLE
Fix test suite and yfinance compatibility

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+import pandas as pd
 import streamlit as st
 
 
@@ -44,9 +45,7 @@ def test_caption_without_yfinance(monkeypatch):
     monkeypatch.setattr(st.sidebar, 'caption', lambda msg: msgs.append(msg))
     load_app(None)
     assert msgs[-1] == 'yfinance unavailable'
-=======
-import pandas as pd
-import streamlit as st
+
 
 
 def reload_app(monkeypatch, import_error=False):


### PR DESCRIPTION
## Summary
- adjust Prefect flows to skip progress arg when unsupported
- simplify YFPricesMissingError wrapper
- fix dashboard test file formatting
- update yfinance compatibility tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853dafa43d8833383d9a9b545b4583e