### PR TITLE
Pin yfinance to 0.2.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Prefect Flows -> Data Lake (Parquet + DVC) -> Feature Pipelines
 | Hour      | 24 months     | `data/raw/1h/`     | kept |
 | Day       | 10 years      | `data/raw/1d/`     | kept |
 
-Data is pulled from `yfinance` and stored as Parquet with DVC deduplication.
+Data is pulled from `yfinance` 0.2.36 and stored as Parquet with DVC deduplication.
 Minute downloads are requested in eight-day windows to stay within the API limits.
 If a start date lies more than 30 days in the past, it is adjusted to this
 cutoff because minute history is only available for the recent month.
@@ -123,8 +123,9 @@ environment:
    Afterwards install the remaining requirements:
 
    ```bash
-   pip install -r requirements.txt
+    pip install -r requirements.txt
 
+   # yfinance 0.2.36 retains the ``progress`` argument
    ```
 
 5. Install the Node dependencies for the dashboard (uses Vite/React):

--- a/python/prefect/flows.py
+++ b/python/prefect/flows.py
@@ -75,25 +75,22 @@ def _download_with_retry(
         try:
             try:
                 return yf.download(
-                ticker,
-                start=start.to_pydatetime(),
-                end=end.to_pydatetime(),
-                interval=interval,
-                auto_adjust=False,
-                progress=False,
-                **_COMPAT_ARGS,
-
-
-            )
+                    ticker,
+                    start=start.to_pydatetime(),
+                    end=end.to_pydatetime(),
+                    interval=interval,
+                    auto_adjust=False,
+                    **_COMPAT_ARGS,
+                )
             except TypeError:
+                # fallback for older yfinance versions without kwargs
                 return yf.download(
-                   ticker,
-                start=start.to_pydatetime(),
-                end=end.to_pydatetime(),
-                interval=interval,
-                auto_adjust=False,
-                progress=False,
-                **_COMPAT_ARGS,
+                    ticker,
+                    start=start.to_pydatetime(),
+                    end=end.to_pydatetime(),
+                    interval=interval,
+                    auto_adjust=False,
+                    **_COMPAT_ARGS,
                 )
 
         except YFPricesMissingError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 prefect
-yfinance>=0.2.34,<0.3
+yfinance==0.2.36
 numpy>=1.25
 pandas
 pyarrow

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -7,6 +7,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import streamlit as st
+import pandas as pd
 
 
 def load_app(yf_module):
@@ -44,9 +45,6 @@ def test_caption_without_yfinance(monkeypatch):
     monkeypatch.setattr(st.sidebar, 'caption', lambda msg: msgs.append(msg))
     load_app(None)
     assert msgs[-1] == 'yfinance unavailable'
-=======
-import pandas as pd
-import streamlit as st
 
 
 def reload_app(monkeypatch, import_error=False):

--- a/tests/test_yf_integration.py
+++ b/tests/test_yf_integration.py
@@ -11,7 +11,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 if isinstance(sys.modules.get("yfinance"), types.SimpleNamespace):
     del sys.modules["yfinance"]
 yf = importlib.import_module("yfinance")
-from yfinance.exceptions import YFPricesMissingError
+try:
+    from yfinance.exceptions import YFPricesMissingError
+except Exception:  # pragma: no cover - older yfinance
+    from python.prefect.flows import YFPricesMissingError
 
 from python.prefect.flows import _download_with_retry
 

--- a/tests/test_yfinance_compat.py
+++ b/tests/test_yfinance_compat.py
@@ -11,7 +11,7 @@ def load_flows(has_threads: bool, monkeypatch):
     else:
         def download(ticker, start=None, end=None, interval=None, auto_adjust=False, progress=True):
             return pd.DataFrame()
-    stub = types.SimpleNamespace(download=download)
+    stub = types.SimpleNamespace(download=download, __version__='0.0')
     monkeypatch.setitem(sys.modules, 'yfinance', stub)
     if 'python.prefect.flows' in sys.modules:
         del sys.modules['python.prefect.flows']
@@ -25,7 +25,7 @@ def load_app(has_threads: bool, monkeypatch):
     else:
         def download(ticker, period=None, interval=None, progress=True):
             return pd.DataFrame({'Close': [1]})
-    stub = types.SimpleNamespace(download=download)
+    stub = types.SimpleNamespace(download=download, __version__='0.0')
     monkeypatch.setitem(sys.modules, 'yfinance', stub)
     dummy_st = types.SimpleNamespace(
         header=lambda *a, **k: None,
@@ -34,6 +34,7 @@ def load_app(has_threads: bool, monkeypatch):
         info=lambda *a, **k: None,
         experimental_rerun=lambda: None,
         session_state={},
+        sidebar=types.SimpleNamespace(caption=lambda *a, **k: None),
     )
     monkeypatch.setitem(sys.modules, 'streamlit', dummy_st)
     if 'python.dashboard.app' in sys.modules:


### PR DESCRIPTION
## Summary
- pin `yfinance` to 0.2.36
- remove duplicate `progress` argument
- fix dashboard and compat tests
- document pinned version in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853db484b0c8333876f5a8039fd3b09