### PR TITLE
Fix imports and retry logic for Prefect flows

### DIFF
--- a/python/dashboard/app.py
+++ b/python/dashboard/app.py
@@ -4,12 +4,13 @@ import pickle
 import time
 from pathlib import Path
 import os
+import inspect
 # ensure yfinance does not use the default SQLite cache
 os.environ.setdefault("YFINANCE_NO_CACHE", "1")
 
 import pandas as pd
 import streamlit as st
-from utils.yf_compat import _COMPAT_ARGS
+from ..utils.yf_compat import _COMPAT_ARGS
 
 try:  # optional, can be missing in test environment
     import yfinance as yf


### PR DESCRIPTION
## Summary
- add missing `inspect` import for dashboard
- import utils with relative path
- add fallback for Prefect 3 task runner
- handle `progress` argument in `_download_with_retry`
- compute compatibility arguments correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e00157c88333a21b1f69b57ee8a0